### PR TITLE
remove original bitmap resource recycling

### DIFF
--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/BlurTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/BlurTransformation.java
@@ -24,8 +24,6 @@ import com.bumptech.glide.load.resource.bitmap.BitmapResource;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Paint;
-import android.graphics.Rect;
 import android.support.v8.renderscript.Allocation;
 import android.support.v8.renderscript.RenderScript;
 import android.support.v8.renderscript.ScriptIntrinsicBlur;
@@ -74,7 +72,6 @@ public class BlurTransformation implements Transformation<Bitmap> {
         blur.forEach(overlayAlloc);
         overlayAlloc.copyTo(bitmap);
 
-        source.recycle();
         rs.destroy();
 
         return BitmapResource.obtain(bitmap, mBitmapPool);

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/ColorFilterTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/ColorFilterTransformation.java
@@ -58,8 +58,6 @@ public class ColorFilterTransformation implements Transformation<Bitmap> {
         paint.setColorFilter(new PorterDuffColorFilter(mColor, PorterDuff.Mode.SRC_ATOP));
         canvas.drawBitmap(source, 0, 0, paint);
 
-        source.recycle();
-
         return BitmapResource.obtain(bitmap, mBitmapPool);
     }
 

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/CropCircleTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/CropCircleTransformation.java
@@ -63,8 +63,6 @@ public class CropCircleTransformation implements Transformation<Bitmap> {
         float r = size / 2f;
         canvas.drawCircle(r, r, r, paint);
 
-        source.recycle();
-
         return BitmapResource.obtain(bitmap, mBitmapPool);
     }
 

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/CropSquareTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/CropSquareTransformation.java
@@ -48,10 +48,6 @@ public class CropSquareTransformation implements Transformation<Bitmap> {
             bitmap = Bitmap.createBitmap(source, mWidth, mHeight, size, size);
         }
 
-        if (bitmap != source) {
-            source.recycle();
-        }
-
         return BitmapResource.obtain(bitmap, mBitmapPool);
     }
 

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/CropTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/CropTransformation.java
@@ -71,8 +71,6 @@ public class CropTransformation implements Transformation<Bitmap> {
         Canvas canvas = new Canvas(bitmap);
         canvas.drawBitmap(source, null, targetRect, null);
 
-        source.recycle();
-
         return BitmapResource.obtain(bitmap, mBitmapPool);
     }
 

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/GrayscaleTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/GrayscaleTransformation.java
@@ -56,8 +56,6 @@ public class GrayscaleTransformation implements Transformation<Bitmap> {
         paint.setColorFilter(new ColorMatrixColorFilter(saturation));
         canvas.drawBitmap(source, 0, 0, paint);
 
-        source.recycle();
-
         return BitmapResource.obtain(bitmap, mBitmapPool);
     }
 

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
@@ -62,8 +62,6 @@ public class RoundedCornersTransformation implements Transformation<Bitmap> {
         canvas.drawRoundRect(new RectF(margin, margin, width - margin, height - margin),
                 radius, radius, paint);
 
-        source.recycle();
-
         return BitmapResource.obtain(bitmap, mBitmapPool);
     }
 


### PR DESCRIPTION
According to glide wiki, original bitmap resource recycling is done automatically.
https://github.com/bumptech/glide/wiki/Transformations#bitmap-re-use

I've been getting the following error when showing multiple images, but this pull request fixed it when I tried in my environment.

    java.lang.IllegalArgumentException: Cannot draw recycled bitmaps
            at android.view.GLES20Canvas.drawBitmap(GLES20Canvas.java:772)
            at android.view.GLES20RecordingCanvas.drawBitmap(GLES20RecordingCanvas.java:105)
            at com.bumptech.glide.load.resource.bitmap.GlideBitmapDrawable.draw(GlideBitmapDrawable.java:101)
            at android.widget.ImageView.onDraw(ImageView.java:1028)
            at android.view.View.draw(View.java:14853)