### PR TITLE
Fix memory leak at BlurTransformation.

### DIFF
--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/BlurTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/BlurTransformation.java
@@ -74,6 +74,10 @@ public class BlurTransformation implements Transformation<Bitmap> {
 
   @Override
   public Resource<Bitmap> transform(Resource<Bitmap> resource, int outWidth, int outHeight) {
+    Context context = mContext.get();
+    if(context == null) {
+      return resource;
+    }
     Bitmap source = resource.get();
 
     int width = source.getWidth();
@@ -92,7 +96,7 @@ public class BlurTransformation implements Transformation<Bitmap> {
     paint.setFlags(Paint.FILTER_BITMAP_FLAG);
     canvas.drawBitmap(source, 0, 0, paint);
 
-    RenderScript rs = RenderScript.create(mContext.get());
+    RenderScript rs = RenderScript.create(context);
     Allocation input = Allocation.createFromBitmap(rs, bitmap, Allocation.MipmapControl.MIPMAP_NONE,
         Allocation.USAGE_SCRIPT);
     Allocation output = Allocation.createTyped(rs, input.getType());
@@ -103,8 +107,6 @@ public class BlurTransformation implements Transformation<Bitmap> {
     blur.forEach(output);
     output.copyTo(bitmap);
 
-    source.recycle();
-    resource.recycle();
     rs.destroy();
 
     return BitmapResource.obtain(bitmap, mBitmapPool);

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/BlurTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/BlurTransformation.java
@@ -29,14 +29,13 @@ import com.bumptech.glide.load.Transformation;
 import com.bumptech.glide.load.engine.Resource;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.load.resource.bitmap.BitmapResource;
-import java.lang.ref.WeakReference;
 
 public class BlurTransformation implements Transformation<Bitmap> {
 
   private static int MAX_RADIUS = 25;
   private static int DEFAULT_DOWN_SAMPLING = 1;
 
-  private WeakReference<Context> mContext;
+  private Context mContext;
   private BitmapPool mBitmapPool;
 
   private int mRadius;
@@ -59,14 +58,14 @@ public class BlurTransformation implements Transformation<Bitmap> {
   }
 
   public BlurTransformation(Context context, BitmapPool pool, int radius, int sampling) {
-    mContext = new WeakReference<>(context);
+    mContext = context.getApplicationContext();
     mBitmapPool = pool;
     mRadius = radius;
     mSampling = sampling;
   }
 
   public BlurTransformation(Context context, int radius, int sampling) {
-    mContext = new WeakReference<>(context);
+    mContext = context.getApplicationContext();
     mBitmapPool = Glide.get(context).getBitmapPool();
     mRadius = radius;
     mSampling = sampling;
@@ -74,10 +73,6 @@ public class BlurTransformation implements Transformation<Bitmap> {
 
   @Override
   public Resource<Bitmap> transform(Resource<Bitmap> resource, int outWidth, int outHeight) {
-    Context context = mContext.get();
-    if(context == null) {
-      return resource;
-    }
     Bitmap source = resource.get();
 
     int width = source.getWidth();
@@ -96,7 +91,7 @@ public class BlurTransformation implements Transformation<Bitmap> {
     paint.setFlags(Paint.FILTER_BITMAP_FLAG);
     canvas.drawBitmap(source, 0, 0, paint);
 
-    RenderScript rs = RenderScript.create(context);
+    RenderScript rs = RenderScript.create(mContext);
     Allocation input = Allocation.createFromBitmap(rs, bitmap, Allocation.MipmapControl.MIPMAP_NONE,
         Allocation.USAGE_SCRIPT);
     Allocation output = Allocation.createTyped(rs, input.getType());


### PR DESCRIPTION
@wasabeef 

Hi,
I investigate memory leaks in my project using by [LeakCanary](https://github.com/square/leakcanary).
I found the memory leaks in BlurTransformation.
Maybe you need to modify other classes, for example, `MaskTransformation` if this solution is correct.


* LeakCanary Logs

```
* GC ROOT static com.bumptech.glide.load.engine.cache.DiskLruCacheWrapper.wrapper
* references com.bumptech.glide.load.engine.cache.DiskLruCacheWrapper.safeKeyGenerator
* references com.bumptech.glide.load.engine.cache.SafeKeyGenerator.loadIdToSafeHash
* references com.bumptech.glide.util.LruCache.cache
* references java.util.LinkedHashMap.table
* references array java.util.HashMap$HashMapEntry[].[111]
* references java.util.LinkedHashMap$LinkedEntry.key
* references com.bumptech.glide.load.engine.EngineKey.transformation
* references com.bumptech.glide.load.MultiTransformation.transformations
* references java.util.Arrays$ArrayList.a
* references array com.bumptech.glide.load.resource.gifbitmap.GifBitmapWrapperTransformation[].[0]
* references com.bumptech.glide.load.resource.gifbitmap.GifBitmapWrapperTransformation.bitmapTransformation
* references jp.wasabeef.glide.transformations.BlurTransformation.mContext
* leaks MyActivity instance

```