### PR TITLE
Fixes RoundedCornersTransformation width/height

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.novoda:bintray-release:0.3.4'
     }
 }

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
@@ -39,11 +39,11 @@ public class RoundedCornersTransformation implements Transformation<Bitmap> {
     DIAGONAL_FROM_TOP_LEFT, DIAGONAL_FROM_TOP_RIGHT
   }
 
-  private BitmapPool mBitmapPool;
-  private int mRadius;
-  private int mDiameter;
-  private int mMargin;
-  private CornerType mCornerType;
+  private final BitmapPool mBitmapPool;
+  private final int mRadius;
+  private final int mDiameter;
+  private final int mMargin;
+  private final CornerType mCornerType;
 
   public RoundedCornersTransformation(Context context, int radius, int margin) {
     this(context, radius, margin, CornerType.ALL);
@@ -68,11 +68,8 @@ public class RoundedCornersTransformation implements Transformation<Bitmap> {
   }
 
   @Override
-  public Resource<Bitmap> transform(Resource<Bitmap> resource, int outWidth, int outHeight) {
+  public Resource<Bitmap> transform(Resource<Bitmap> resource, int width, int height) {
     Bitmap source = resource.get();
-
-    int width = source.getWidth();
-    int height = source.getHeight();
 
     Bitmap bitmap = mBitmapPool.get(width, height, Bitmap.Config.ARGB_8888);
     if (bitmap == null) {


### PR DESCRIPTION
It should be using the output width/height, not the source Bitmap
dimensions. This allows this transformation to play nicely with others.
Fixes #16