### PR TITLE
add not implemented method from Key interface

### DIFF
--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
@@ -255,5 +255,5 @@ public class RoundedCornersTransformation implements Transformation<Bitmap> {
   
   @Override void updateDiskCacheKey(MessageDigest messageDigest) {
     // no op
-  };
+  }
 }

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
@@ -252,4 +252,8 @@ public class RoundedCornersTransformation implements Transformation<Bitmap> {
     return "RoundedTransformation(radius=" + mRadius + ", margin=" + mMargin + ", diameter="
         + mDiameter + ", cornerType=" + mCornerType.name() + ")";
   }
+  
+  @Override void updateDiskCacheKey(MessageDigest messageDigest) {
+    // no op
+  };
 }


### PR DESCRIPTION
in glide 4.0, RoundedCornersTransformation need implement method updateDiskCacheKey.

Exception like this:
```java.lang.AbstractMethodError: abstract method "void com.bumptech.glide.load.Key.updateDiskCacheKey(java.security.MessageDigest)"```