### PR TITLE
set canvas bitmap density

### DIFF
--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/BitmapTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/BitmapTransformation.java
@@ -58,8 +58,12 @@ public abstract class BitmapTransformation implements Transformation<Bitmap> {
     return result;
   }
 
-  protected abstract Bitmap transform(@NonNull Context context, @NonNull BitmapPool pool,
-                                      @NonNull Bitmap toTransform, int outWidth, int outHeight);
+    void setCanvasBitmapDensity(@NonNull Bitmap toTransform, @NonNull Bitmap canvasBitmap) {
+        canvasBitmap.setDensity(toTransform.getDensity());
+    }
+
+    protected abstract Bitmap transform(@NonNull Context context, @NonNull BitmapPool pool,
+                                        @NonNull Bitmap toTransform, int outWidth, int outHeight);
 
   @Override
   public abstract void updateDiskCacheKey(@NonNull MessageDigest messageDigest);

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/BlurTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/BlurTransformation.java
@@ -64,6 +64,8 @@ public class BlurTransformation extends BitmapTransformation {
 
     Bitmap bitmap = pool.get(scaledWidth, scaledHeight, Bitmap.Config.ARGB_8888);
 
+    setCanvasBitmapDensity(toTransform,bitmap);
+
     Canvas canvas = new Canvas(bitmap);
     canvas.scale(1 / (float) sampling, 1 / (float) sampling);
     Paint paint = new Paint();

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/ColorFilterTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/ColorFilterTransformation.java
@@ -51,11 +51,13 @@ public class ColorFilterTransformation extends BitmapTransformation {
         toTransform.getConfig() != null ? toTransform.getConfig() : Bitmap.Config.ARGB_8888;
     Bitmap bitmap = pool.get(width, height, config);
 
-    Canvas canvas = new Canvas(bitmap);
-    Paint paint = new Paint();
-    paint.setAntiAlias(true);
-    paint.setColorFilter(new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP));
-    canvas.drawBitmap(toTransform, 0, 0, paint);
+        setCanvasBitmapDensity(toTransform, bitmap);
+
+        Canvas canvas = new Canvas(bitmap);
+        Paint paint = new Paint();
+        paint.setAntiAlias(true);
+        paint.setColorFilter(new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP));
+        canvas.drawBitmap(toTransform, 0, 0, paint);
 
     return bitmap;
   }

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/CropTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/CropTransformation.java
@@ -76,6 +76,8 @@ public class CropTransformation extends BitmapTransformation {
     float top = getTop(scaledHeight);
     RectF targetRect = new RectF(left, top, left + scaledWidth, top + scaledHeight);
 
+    setCanvasBitmapDensity(toTransform,bitmap);
+
     Canvas canvas = new Canvas(bitmap);
     canvas.drawBitmap(toTransform, null, targetRect, null);
 

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/GrayscaleTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/GrayscaleTransformation.java
@@ -45,6 +45,8 @@ public class GrayscaleTransformation extends BitmapTransformation {
         toTransform.getConfig() != null ? toTransform.getConfig() : Bitmap.Config.ARGB_8888;
     Bitmap bitmap = pool.get(width, height, config);
 
+    setCanvasBitmapDensity(toTransform,bitmap);
+
     Canvas canvas = new Canvas(bitmap);
     ColorMatrix saturation = new ColorMatrix();
     saturation.setSaturation(0f);

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/MaskTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/MaskTransformation.java
@@ -64,6 +64,8 @@ public class MaskTransformation extends BitmapTransformation {
 
     Drawable mask = Utils.getMaskDrawable(context.getApplicationContext(), maskId);
 
+    setCanvasBitmapDensity(toTransform,bitmap);
+
     Canvas canvas = new Canvas(bitmap);
     mask.setBounds(0, 0, width, height);
     mask.draw(canvas);

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/RoundedCornersTransformation.java
@@ -68,13 +68,15 @@ public class RoundedCornersTransformation extends BitmapTransformation {
     Bitmap bitmap = pool.get(width, height, Bitmap.Config.ARGB_8888);
     bitmap.setHasAlpha(true);
 
-    Canvas canvas = new Canvas(bitmap);
-    Paint paint = new Paint();
-    paint.setAntiAlias(true);
-    paint.setShader(new BitmapShader(toTransform, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP));
-    drawRoundRect(canvas, paint, width, height);
-    return bitmap;
-  }
+        setCanvasBitmapDensity(toTransform, bitmap);
+
+        Canvas canvas = new Canvas(bitmap);
+        Paint paint = new Paint();
+        paint.setAntiAlias(true);
+        paint.setShader(new BitmapShader(toTransform, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP));
+        drawRoundRect(canvas, paint, width, height);
+        return bitmap;
+    }
 
   private void drawRoundRect(Canvas canvas, Paint paint, float width, float height) {
     float right = width - margin;

--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/SupportRSBlurTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/SupportRSBlurTransformation.java
@@ -67,11 +67,13 @@ public class SupportRSBlurTransformation extends BitmapTransformation {
 
     Bitmap bitmap = pool.get(scaledWidth, scaledHeight, Bitmap.Config.ARGB_8888);
 
-    Canvas canvas = new Canvas(bitmap);
-    canvas.scale(1 / (float) sampling, 1 / (float) sampling);
-    Paint paint = new Paint();
-    paint.setFlags(Paint.FILTER_BITMAP_FLAG);
-    canvas.drawBitmap(toTransform, 0, 0, paint);
+        setCanvasBitmapDensity(toTransform, bitmap);
+
+        Canvas canvas = new Canvas(bitmap);
+        canvas.scale(1 / (float) sampling, 1 / (float) sampling);
+        Paint paint = new Paint();
+        paint.setFlags(Paint.FILTER_BITMAP_FLAG);
+        canvas.drawBitmap(toTransform, 0, 0, paint);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       try {


### PR DESCRIPTION
This is an awesome library， thank the author.
when my project refers to [AndroidAutoSize](https://github.com/JessYanCoding/AndroidAutoSize)(get by change density adjust size) and glide-transformations，it occur an issue. By BlurTransformation handle bitmap is incorrect. But I've solved it. The reason is the two bitmaps of density is an inconsistent.
![image](https://user-images.githubusercontent.com/25290829/49789411-e8dba380-fd66-11e8-8f1d-dde94ca2f5e5.png)
![image](https://user-images.githubusercontent.com/25290829/49789479-14f72480-fd67-11e8-993d-dcecd7907242.png)
pool.get didn't take density
![image](https://user-images.githubusercontent.com/25290829/49789458-06107200-fd67-11e8-91be-a936d83c5d36.png)
this is an incorrect result. if the right result should be full in.
![image](https://user-images.githubusercontent.com/25290829/49789580-51c31b80-fd67-11e8-9302-91987d6b5502.png)



