### PR TITLE
Always call destroy on local render script object

### DIFF
--- a/transformations/src/main/java/jp/wasabeef/glide/transformations/internal/RSBlur.java
+++ b/transformations/src/main/java/jp/wasabeef/glide/transformations/internal/RSBlur.java
@@ -47,11 +47,7 @@ public class RSBlur {
       output.copyTo(bitmap);
     } finally {
       if (rs != null) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-          RenderScript.releaseAllContexts();
-        } else {
-          rs.destroy();
-        }
+        rs.destroy();
       }
       if (input != null) {
         input.destroy();


### PR DESCRIPTION
`StrictMode` reports that the local `rs` object leaks memory if it does not call `destroy()` on the local reference. Always calling `destroy()` explicitly (when not null) fixes this memory leak.

```
E/StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
    java.lang.Throwable: Explicit termination method 'destroy' not called
        at dalvik.system.CloseGuard.open(CloseGuard.java:180)
        at android.renderscript.Element.<init>(Element.java:1094)
        at android.renderscript.Element.createPixel(Element.java:1265)
        at android.renderscript.Element.RGBA_8888(Element.java:639)
        at android.renderscript.Allocation.elementFromBitmap(Allocation.java:2762)
        at android.renderscript.Allocation.typeFromBitmap(Allocation.java:2772)
        at android.renderscript.Allocation.createFromBitmap(Allocation.java:2811)
        at jp.wasabeef.glide.transformations.internal.RSBlur.blur(RSBlur.java:39)
        at jp.wasabeef.glide.transformations.BlurTransformation.transform(BlurTransformation.java:79)
        at jp.wasabeef.glide.transformations.BitmapTransformation.transform(BitmapTransformation.java:50)
```